### PR TITLE
Fix - TextField max Lines

### DIFF
--- a/app/src/main/java/org/compose_projects/socialocal/ui/components/textField/styles/SLTextFieldSizes.kt
+++ b/app/src/main/java/org/compose_projects/socialocal/ui/components/textField/styles/SLTextFieldSizes.kt
@@ -29,7 +29,7 @@ object SLTextFieldSizes {
             override val height: Dp = 55.dp
             override val width: Dp = 300.dp
             override val shape: RoundedCornerShape = RoundedCornerShape(20.dp)
-            override val maxLines: Int = 5000
+            override val maxLines: Int = 200
             override val maxChar: Int = 10000
 
         }


### PR DESCRIPTION
Se cambio el maxLines por defecto a 200, dentro del textField, esto ocasionaba un crash en algunos dispositivos y escalas de fuente